### PR TITLE
Fixing code and deprecation notices for Symfony 4+

### DIFF
--- a/DependencyInjection/AlexdwTrumbowygExtension.php
+++ b/DependencyInjection/AlexdwTrumbowygExtension.php
@@ -31,7 +31,7 @@ class AlexdwTrumbowygExtension extends Extension
         $container->setParameter('alexdw_trumbowyg.form.type.class', $config['class']);
         $container->setParameter('twig.form.resources', array_merge(
             $container->getParameter('twig.form.resources'),
-            array('AlexdwTrumbowygBundle:Form:trumbowyg_widget.html.twig')
+            array('@AlexdwTrumbowyg/Form/trumbowyg_widget.html.twig')
         ));
 
         $config['base_path'] = ltrim($config['base_path'], '/');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('alexdw_trumbowyg');
-        $rootNode = $treeBuilder->getRootNode();
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('alexdw_trumbowyg');
+        }
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('alexdw_trumbowyg');
+        $treeBuilder = new TreeBuilder('alexdw_trumbowyg');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,7 +6,7 @@ services:
           - { name: form.type }
     alexdw_trumbowyg.twig_extension:
             class: Alexdw\TrumbowygBundle\Twig\TrumbowygExtension
-            arguments: ["@service_container"]
             public: false
+            autowire: true
             tags:
                 - { name: twig.extension }

--- a/Resources/views/Form/trumbowyg_widget.html.twig
+++ b/Resources/views/Form/trumbowyg_widget.html.twig
@@ -1,5 +1,5 @@
 {% block trumbowyg_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
         <script type="text/javascript">
             trumbowyg_instances = ( typeof trumbowyg_instances != 'undefined' && trumbowyg_instances instanceof Array ) ? trumbowyg_instances : []
@@ -17,5 +17,5 @@
             trumbowyg_instances.push(instance_data);
 
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock trumbowyg_widget %}

--- a/Resources/views/Init/js.html.twig
+++ b/Resources/views/Init/js.html.twig
@@ -4,12 +4,12 @@
 <script type="text/javascript" src="{{ asset(base_path ~ 'trumbowyg.js') }}"></script>
 <script type="text/javascript" src="{{ asset(base_path ~ 'langs/'~ language ~ ".min.js") }}"></script>
 <script type="text/javascript">
-    {% spaceless %}
+    {% apply spaceless %}
     $(function () {
         $.trumbowyg.svgPath = "{{ svg_path }}";
         trumbowyg_instances.forEach(function(item) {
             $("#" + item.id).trumbowyg(item.options);
         })
     });
-    {% endspaceless %}
+    {% endapply %}
 </script>

--- a/Twig/TrumbowygExtension.php
+++ b/Twig/TrumbowygExtension.php
@@ -5,13 +5,15 @@ namespace Alexdw\TrumbowygBundle\Twig;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Environment;
+use Twig_Extension;
+use Twig_SimpleFunction;
 
 /**
  * Twig Extension for Trumbowyg support.
  *
  * @author Álex Martín <alex@alexdw.com>
  */
-class TrumbowygExtension extends \Twig_Extension
+class TrumbowygExtension extends Twig_Extension
 {
     /**
      * @var ContainerInterface $container Container interface
@@ -27,7 +29,7 @@ class TrumbowygExtension extends \Twig_Extension
      * Initialize trumbowyg helper
      *
      * @param ContainerInterface $container
-     * @param TemplateInterface $template
+     * @param Environment $environment
      */
     public function __construct(ContainerInterface $container, Environment $environment)
     {
@@ -67,12 +69,12 @@ class TrumbowygExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'trumbowyg_js' => new \Twig_SimpleFunction(
+            'trumbowyg_js' => new Twig_SimpleFunction(
                 'trumbowyg_js',
                 array($this, 'trumbowygJs'),
                 array('is_safe' => array('html'))
             ),
-            'trumbowyg_css' => new \Twig_SimpleFunction(
+            'trumbowyg_css' => new Twig_SimpleFunction(
                 'trumbowyg_css',
                 array($this, 'trumbowygCss'),
                 array('is_safe' => array('html'))
@@ -101,9 +103,9 @@ class TrumbowygExtension extends \Twig_Extension
 
 
     }
+
     /**
      * Trumbowyg JS init
-     * @param array $options
      * @return string
      */
     public function trumbowygCss()

--- a/Twig/TrumbowygExtension.php
+++ b/Twig/TrumbowygExtension.php
@@ -2,7 +2,9 @@
 
 namespace Alexdw\TrumbowygBundle\Twig;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Environment;
 
 /**
  * Twig Extension for Trumbowyg support.
@@ -17,13 +19,20 @@ class TrumbowygExtension extends \Twig_Extension
     protected $container;
 
     /**
+     * @var Environment $environment
+     */
+    protected $environment;
+
+    /**
      * Initialize trumbowyg helper
      *
      * @param ContainerInterface $container
+     * @param TemplateInterface $template
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, Environment $environment)
     {
         $this->container = $container;
+        $this->environment = $environment;
     }
 
     /**
@@ -82,12 +91,12 @@ class TrumbowygExtension extends \Twig_Extension
         $config = array_merge($config, $options);
 
 
-        return $this->getService('templating')->render('AlexdwTrumbowygBundle:Init:js.html.twig', array(
-            'svg_path'     => $config['svg_path'],
+        return $this->environment->render('@AlexdwTrumbowyg/Init/js.html.twig', array(
+            'svg_path'      => $config['svg_path'],
             'base_path'     => $config['base_path'],
-            'language'     => $config['language'],
-            'include_jquery'     => $config['include_jquery'],
-            'jquery_path'     => $config['jquery_path'],
+            'language'      => $config['language'],
+            'include_jquery'=> $config['include_jquery'],
+            'jquery_path'   => $config['jquery_path'],
         ));
 
 
@@ -100,8 +109,8 @@ class TrumbowygExtension extends \Twig_Extension
     public function trumbowygCss()
     {
         $config = $this->getParameter('alexdw_trumbowyg.config');
-        return $this->getService('templating')->render('AlexdwTrumbowygBundle:Init:css.html.twig', array(
-            'base_path'     => $config['base_path'],
+        return $this->environment->render('@AlexdwTrumbowyg/Init/css.html.twig', array(
+            'base_path' => $config['base_path'],
         ));
     }
 

--- a/Twig/TrumbowygExtension.php
+++ b/Twig/TrumbowygExtension.php
@@ -5,8 +5,8 @@ namespace Alexdw\TrumbowygBundle\Twig;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Environment;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension as Twig_Extension;
+use Twig\TwigFunction;
 
 /**
  * Twig Extension for Trumbowyg support.
@@ -69,12 +69,12 @@ class TrumbowygExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            'trumbowyg_js' => new Twig_SimpleFunction(
+            'trumbowyg_js' => new TwigFunction(
                 'trumbowyg_js',
                 array($this, 'trumbowygJs'),
                 array('is_safe' => array('html'))
             ),
-            'trumbowyg_css' => new Twig_SimpleFunction(
+            'trumbowyg_css' => new TwigFunction(
                 'trumbowyg_css',
                 array($this, 'trumbowygCss'),
                 array('is_safe' => array('html'))

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,14 @@
         "MIT"
     ],
     "require" : {
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0"
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
+        "twig/twig": "^1.34|^2.4"
     },
     "autoload" : {
         "psr-4" : {
             "Alexdw\\TrumbowygBundle\\" : ""
         }
     },
-    "repositories" : [{
-    }],
     "minimum-stability": "dev",
     "extra" : {
         "branch-alias" : {


### PR DESCRIPTION
* Fixing some deprecations, getting rid of getservice templating
* Fixing treeBuilder deprecation (SF4.2+)
* Fixing annotation, housekeeping
* Add missing version constraint for `twig/twig` package